### PR TITLE
Upgrade ruby version to 2.6-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.6-alpine
 MAINTAINER Tobias L. Maier <tobias.maier@baucloud.com>
 
 RUN echo 'gem: --no-document' >> /etc/gemrc


### PR DESCRIPTION
There is a problem with the 2.3 ruby version. `rubyzip` versions cannot be satisfied:

```bash
ERROR:  Error installing dpl-elastic_beanstalk:
	The last version of rubyzip (>= 0) to support your Ruby & RubyGems was 1.3.0. Try installing it with `gem install rubyzip -v 1.3.0` and then running the current command again
	rubyzip requires Ruby version >= 2.4. The current ruby version is 2.3.0.
```